### PR TITLE
fix Makefile

### DIFF
--- a/platforms/linux/turboz/Makefile
+++ b/platforms/linux/turboz/Makefile
@@ -6,17 +6,23 @@ TURBOOBJS= $(TOD)/FlexMemoryRule.o $(TOD)/Symbols.o $(TOD)/Disassembly.o $(TOD)/
 
 
 OBJS= $(GEAROBJS) $(TURBOOBJS) $(DISOBJS)
-CFLAGS= -Wall -g -DDISASM_GEARSYSTEM -I /usr/include/rhtvision -I ../../../src -I ../../../src/z80ex/include  -std=c++11 
-LDFLAGS= -lrhtv -pthread 
+CFLAGS= -Wall -g -DDISASM_GEARSYSTEM -I /usr/include/rhtvision -I ../../../src -I ../../../src/z80ex/include
+LDFLAGS= -lrhtv -pthread
+CPPFLAGS= -std=c++11 
 
 turboz: $(OBJS)
 	g++ -o ./turboz $(OBJS) $(LDFLAGS)
 
+#dependents
+-include $(OBJS:%.o=%.d)
+
 $(OD)/%.o: ../../../src/%.cpp
-	g++ $(CFLAGS) -c $< -o $@
+	g++ $(CFLAGS) $(CPPFLAGS) -g -c -o $@ $<
+	g++ -MM $(CFLAGS) $(CPPFLAGS) $< -MF $(@:.o=.d) -MT $@
 
 $(OD)/z80ex/%.o: ../../../src/z80ex/%.c
-	gcc $(CFLAGS) -c $< -o $@ -I ../../../src/z80ex/include
+	gcc $(CFLAGS) -g -c -o $@ $< -I ../../../src/z80ex/include
+	gcc -MM $(CFLAGS) $< -MF $(@:.o=.d) -MT $@ -I ../../../src/z80ex/include
 
 clean:
 	rm $(OBJS) ./turboz

--- a/src/turboz/turboz.cpp
+++ b/src/turboz/turboz.cpp
@@ -104,11 +104,66 @@ enum TVPalette{
   TBackground=1,
   TMenuView_TextNormal=2,
   TMenuView_TextDisabled=3,
-  TMenuView_TextShorcut=4,
+  TMenuView_TextShortcut=4,
   TMenuView_SelectedNormal=5,
   TMenuView_SelectedDisabled=6,
-  TMenuView_SelectedShorcut=7,
-
+  TMenuView_SelectedShortcut=7,
+  TWindowBlue_FramePassive=8,
+  TWindowBlue_FrameActive=9,
+  TWindowBlue_FrameIcon=10,
+  TWindowBlue_ScrollBarPage=11,
+  TWindowBlue_ScrollBarReserved=12,
+  TWindowBlue_ScrollerNormalText=13,
+  TWindowBlue_ScrollerSelectedText=14,
+  TWindowBlue_Reserved=15,
+  TWindowCyan_FramePassive=16,
+  TWindowCyan_FrameActive=17,
+  TWindowCyan_FrameIcon=18,
+  TWindowCyan_ScrollBarPage=19,
+  TWindowCyan_ScrollBarReserved=20,
+  TWindowCyan_ScrollerNormalText=21,
+  TWindowCyan_ScrollerSelectedText=22,
+  TWindowCyan_Reserved=23,
+  TWindowGray_FramePassive=24,
+  TWindowGray_FrameActive=25,
+  TWindowGray_FrameIcon=26,
+  TWindowGray_ScrollBarPage=27,
+  TWindowGray_ScrollBarReserved=28,
+  TWindowGray_ScrollerNormalText=29,
+  TWindowGray_ScrollerSelectedText=30,
+  TWindowGray_Reserved=31,
+  TDialog_FramePassive=32,
+  TDialog_FrameActive=33,
+  TDialog_FrameIcon=34,
+  TDialog_ScrollBarPage=35,
+  TDialog_ScrollBarControls=36,
+  TDialog_StaticText=37,
+  TDialog_LabelNormal=38,
+  TDialog_LabelHighlight=39,
+  TDialog_LabelShortcut=40,
+  TDialog_ButtonNormal=41,
+  TDialog_ButtonDefault=42,
+  TDialog_ButtonSelected=43,
+  TDialog_ButtonDisabled=44,
+  TDialog_ButtonShortcut=45,
+  TDialog_ButtonShadow=46,
+  TDialog_ClusterNormal=47,
+  TDialog_ClusterSelected=48,
+  TDialog_ClusterShortcut=49,
+  TDialog_InputLineNormal=50,
+  TDialog_InputLineSelected=51,
+  TDialog_InputLineArrows=52,
+  TDialog_HistoryArrow=53,
+  TDialog_HistorySides=54,
+  TDialog_HistoryWindowScrollBarPage=55,
+  TDialog_HistoryWindowScrollBarControls=56,
+  TDialog_ListViewerNormal=57,
+  TDialog_ListViewerFocused=58,
+  TDialog_ListViewerSelected=59,
+  TDialog_ListViewerDivider=60,
+  TDialog_InfoPane=61,
+  TDialog_Reserved1=62,
+  TDialog_Reserved2=63
 };
 
 
@@ -125,10 +180,10 @@ TurboZ::TurboZ(System& _system) :
   palette[TBackground]=palette::BLACK*palette::BACKGROUND+palette::GREEN;
   palette[TMenuView_TextNormal]=palette::BLACK*palette::BACKGROUND+palette::CYAN;
   palette[TMenuView_TextDisabled]=palette::BLACK*palette::BACKGROUND+palette::DARKGRAY;
-  palette[TMenuView_TextShorcut]=palette::BLACK*palette::BACKGROUND+palette::CYAN+palette::LIGHT;
+  palette[TMenuView_TextShortcut]=palette::BLACK*palette::BACKGROUND+palette::CYAN+palette::LIGHT;
   palette[TMenuView_SelectedNormal]=palette::CYAN*palette::BACKGROUND+palette::WHITE;
   palette[TMenuView_SelectedDisabled]=palette::CYAN*palette::BACKGROUND+palette::DARKGRAY;
-  palette[TMenuView_SelectedShorcut]=palette::CYAN*palette::BACKGROUND+palette::GRAY;
+  palette[TMenuView_SelectedShortcut]=palette::CYAN*palette::BACKGROUND+palette::GRAY;
 }
 
 void TurboZ::handleEvent(TEvent& event){


### PR DESCRIPTION
see **Files changed** ⤴️
- now compiles related files when header is changed (no more make clean each time)
- only use -std=c++11 flag for g++ 
 `invalid argument '-std=c++11' not allowed with 'C/ObjC'`